### PR TITLE
Add basic Flask app for worker productivity tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # General
-Depositorio general base
+
+Repositorio general base
+
+## App de rendimientos
+
+Aplicación Flask sencilla para registrar el rendimiento de trabajadores de obra.
+
+### Requisitos
+- Python 3.8+
+- Instalar dependencias: `pip install -r requirements.txt`
+
+### Ejecutar
+
+```
+python app.py
+```
+La aplicación estará disponible en http://localhost:5000.
+
+### Pruebas
+
+```
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,45 @@
+from flask import Flask, render_template, request, redirect
+import sqlite3
+from datetime import datetime
+
+app = Flask(__name__)
+DB_PATH = 'workers.db'
+
+def init_db():
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute('''
+            CREATE TABLE IF NOT EXISTS workers (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                name TEXT NOT NULL,
+                role TEXT,
+                performance REAL,
+                date TEXT
+            )
+        ''')
+        conn.commit()
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    init_db()
+    if request.method == 'POST':
+        name = request.form['name']
+        role = request.form['role']
+        performance = request.form['performance']
+        date = request.form['date'] or datetime.now().strftime('%Y-%m-%d')
+        with sqlite3.connect(DB_PATH) as conn:
+            c = conn.cursor()
+            c.execute('INSERT INTO workers (name, role, performance, date) VALUES (?, ?, ?, ?)',
+                      (name, role, performance, date))
+            conn.commit()
+        return redirect('/')
+
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute('SELECT name, role, performance, date FROM workers')
+        workers = c.fetchall()
+    return render_template('index.html', workers=workers)
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True, host='0.0.0.0', port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+pytest

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="es">
+<head>
+    <meta charset="utf-8">
+    <title>Rendimientos</title>
+</head>
+<body>
+    <h1>Registro de Rendimientos</h1>
+    <form method="post">
+        <label>Nombre: <input type="text" name="name" required></label><br>
+        <label>Puesto: <input type="text" name="role"></label><br>
+        <label>Rendimiento: <input type="number" step="0.01" name="performance"></label><br>
+        <label>Fecha: <input type="date" name="date"></label><br>
+        <button type="submit">Guardar</button>
+    </form>
+
+    <h2>Trabajadores</h2>
+    <table border="1">
+        <tr><th>Nombre</th><th>Puesto</th><th>Rendimiento</th><th>Fecha</th></tr>
+        {% for w in workers %}
+        <tr>
+            <td>{{ w[0] }}</td>
+            <td>{{ w[1] }}</td>
+            <td>{{ w[2] }}</td>
+            <td>{{ w[3] }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,17 @@
+import os
+import tempfile
+import pytest
+import app as app_module
+
+@pytest.fixture
+def client():
+    db_fd, app_module.DB_PATH = tempfile.mkstemp()
+    app_module.app.config['TESTING'] = True
+    with app_module.app.test_client() as client:
+        yield client
+    os.close(db_fd)
+    os.unlink(app_module.DB_PATH)
+
+def test_index(client):
+    response = client.get('/')
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- build minimal Flask app with SQLite to log worker performance
- add HTML form and table for listing submissions
- include pytest and documentation

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a49bf3b0548325889738d6a1e66fa8